### PR TITLE
Fix Pkg.dir deprecation.

### DIFF
--- a/test/mathprog.jl
+++ b/test/mathprog.jl
@@ -1,8 +1,14 @@
-include(joinpath(Pkg.dir("MathProgBase"),"test","linprog.jl"))
+if VERSION < v"0.7"
+    testdir = joinpath(Pkg.dir("MathProgBase"), "test")
+else
+    import MathProgBase
+    testdir = joinpath(dirname(pathof(MathProgBase)), "..", "test")
+end
+include(joinpath(testdir, "linprog.jl"))
 linprogtest(ClpSolver())
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","linproginterface.jl"))
+include(joinpath(testdir, "linproginterface.jl"))
 linprogsolvertest(ClpSolver())
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","conicinterface.jl"))
+include(joinpath(testdir, "conicinterface.jl"))
 coniclineartest(ClpSolver())


### PR DESCRIPTION
Replace deprecated `Pkg.dir` with `pathof` construction for Julia 0.7.
