### PR TITLE
Unsafe get function

### DIFF
--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -81,6 +81,7 @@ export
     get_vector_starts,
     get_indices,
     get_constraint_matrix,
+    unsafe_get_constraint_matrix,
     get_vector_lengths,
     get_elements,
     get_obj_value,

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -31,7 +31,10 @@ end
         "linear11",
         # linear12 test requires the InfeasibilityCertificate for variable
         # bounds. These are available through C++, but not via the C interface.
-        "linear12"
+        "linear12",
+        # partial_start requires VariablePrimalStart to be implemented by the
+        # solver.
+        "partial_start"
     ])
 
     @testset "Interval Bridge" begin
@@ -49,7 +52,7 @@ end
     end
     @testset "emptytest" begin
         MOIT.emptytest(solver)
-    end 
+    end
     @testset "copytest" begin
         solver2 = Clp.Optimizer(LogLevel = 0)
         MOIT.copytest(solver,solver2)


### PR DESCRIPTION
This creates get functions which return unsafe arrays and are annotated as such.   It then uses those function where it appears safe.  There should be a slight performance improvement due to fewer memory allocations.

But the chief reason for this improvement is the function ```unsafe_get_constraint_matrix```  which can be used to modify the constraint matrix.

The pull request:
https://github.com/JuliaOpt/Clp.jl/pull/56
Takes advantage of this.