### PR TITLE
add support for LQOI.change_matrix_coefficient

### DIFF
--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -81,6 +81,7 @@ export
     get_vector_starts,
     get_indices,
     get_constraint_matrix,
+    unsafe_get_constraint_matrix,
     get_vector_lengths,
     get_elements,
     get_obj_value,

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -256,7 +256,10 @@ function cached_get_constraint_matrix(instance::Optimizer)
     return instance.cached_constraint_matrix
 end
 
-
+# This function is using an undocumented capability in Clp, by which you can
+# modify the coefficent matrix returned by unsafe_get_constraint_matrix and have
+# the results reflected in the model.  That means that there is no way to add a
+# coefficent only change it.
 function LQOI.change_matrix_coefficient!(instance::Optimizer, row, col, coef)
     A = cached_get_constraint_matrix(instance)
     ind = sparse_value_index(A, row, col)

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -76,7 +76,7 @@ LQOI.supported_objectives(optimizer::Optimizer) = SUPPORTED_OBJECTIVES
 Use this function when ever there is an operation that may change the Clp constraint matrix
 """
 @inline function clear_cached_coefficient_matrix!(opt::Optimizer)
-    ismissing(opt.cached_constraint_matrix) || opt.cached_constraint_matrix = missing
+    ismissing(opt.cached_constraint_matrix) || (opt.cached_constraint_matrix = missing)
     return true
 end
 
@@ -223,7 +223,7 @@ function LQOI.get_rhs(instance::Optimizer, row::Int)
 end
 
 function LQOI.get_linear_constraint(instance::Optimizer, row::Int)::Tuple{Vector{Int}, Vector{Float64}}
-    A = cached_get_constraint_matrix(instance.inner)
+    A = cached_get_constraint_matrix(instance)
     A_row = A[row,:]
     return Array{Int}(A_row.nzind), A_row.nzval
 end

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -31,7 +31,10 @@ end
         "linear11",
         # linear12 test requires the InfeasibilityCertificate for variable
         # bounds. These are available through C++, but not via the C interface.
-        "linear12"
+        "linear12",
+        # partial_start requires VariablePrimalStart to be implemented by the
+        # solver.
+        "partial_start"
     ])
 
     @testset "Interval Bridge" begin
@@ -49,7 +52,7 @@ end
     end
     @testset "emptytest" begin
         MOIT.emptytest(solver)
-    end 
+    end
     @testset "copytest" begin
         solver2 = Clp.Optimizer(LogLevel = 0)
         MOIT.copytest(solver,solver2)


### PR DESCRIPTION
This adds support for ```LQOI.change_matrix_coefficient```. which allows JuMP to use ```set_coefficient``` on constraint variables which previously had been created.  Even with the limitation, it adds a lot of capability to the MOI Clp Interface.

This is a hack that uses the fact the clp_getElement returns a pointer to the actual matrix values.  It is an abuse of the interface.... But it works.

That said I am a bit out of my depth in writing a MOI test that ensures that we can check that this hack continues to work.   

The JuMP test below proves it works
```julia
using Clp
using JuMP
using Test

function coefficient_modification_test(num_vars )
    model = Model(with_optimizer(Clp.Optimizer; LogLevel=0))

    test_vars=@variable(model,test_vars[i=1:num_vars])
    test_bound_var=@variable(model,0<=test_bound_var<=1)

    cons=@constraint(model,test_vars .- (1*test_bound_var) .== 0)
    @objective(model,Max,sum(test_vars))

    optimize!(model)

    if objective_value(model) !=  num_vars
        println("Initial objective was not what was expected :   $(objective_value(model)) != $num_vars")
    else
        println("Initial objective correct")
    end

    for con in cons
        set_coefficient(con,test_bound_var,-2)
    end

    optimize!(model)

    @test objective_value(model) ==  2*num_vars

    if objective_value(model) !=  2*num_vars
        println("After modification objective was not what was expected :   $(objective_value(model)) != $(2*num_vars)")
    else
        println("After modification objective correct")
    end

end
```


