### PR TITLE
Significant improvement in model instantiation time.

### DIFF
--- a/src/Clp.jl
+++ b/src/Clp.jl
@@ -9,6 +9,7 @@ using Compat
 # This 'using' is required to suppress a warning about Clp not having Libdl in its
 # dependencies (Libdl is used by BinaryProvider), e.g.: bicycle1885/CodecZlib.jl#26.
 using Libdl
+import SparseArrays
 
 include("ClpCInterface.jl")
 include("ClpSolverInterface.jl")

--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -440,7 +440,7 @@ function add_rows(model::ClpModel, rows::UnitRange{Int}, rows_lower::AbstractVec
              error("Bounds Vectors must have the same length as rows or the number of rows in A")
          end
     end
-    Ac = transepose(A)  # This is a simple way to remove the adjoint
+    Ac = transpose(A)  # This is a simple way to remove the adjoint
     num_rows=length(rows)
     columns = convert(Vector{Cint},SparseArrays.rowvals(Ac))
     columns .-= 1

--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -500,8 +500,9 @@ end
 function add_columns(model::ClpModel, column_lower::Vector{Float64},
         column_upper::Vector{Float64},
         objective::Vector{Float64},
-        new_columns::SparseMatrixCSC{Float64,Int32})
-    add_columns(model, new_columns.n, column_lower, column_upper, objective, new_columns.colptr-convert(Int32,1), new_columns.rowval-convert(Int32,1), new_columns.nzval)
+        new_columns::SparseMatrixCSC{Float64,T}) where T
+    add_columns(model, new_columns.n, column_lower, column_upper, objective, convert(Vector{Int32},new_columns.colptr).-Int32(1),
+            convert(Vector{Int32},new_columns.rowval).-Int32(1), new_columns.nzval)
 end
 
 

--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -428,7 +428,7 @@ end
 # Add rows.
 function add_rows(model::ClpModel, rows::UnitRange{Int}, rows_lower::AbstractVector{Float64},
         rows_upper::AbstractVector{Float64},
-        A::Adjoint{Float64,SparseMatrixCSC{Float64,Ti}}) where Ti <: Integer
+        A::Transpose{Float64,SparseMatrixCSC{Float64,Ti}}) where Ti <: Integer
     @assert length(rows_upper) == length(rows_upper)
     if length(rows) != length(rows_lower)
         # This is to catch the case where a sparse array may have been passed in
@@ -440,7 +440,7 @@ function add_rows(model::ClpModel, rows::UnitRange{Int}, rows_lower::AbstractVec
              error("Bounds Vectors must have the same length as rows or the number of rows in A")
          end
     end
-    Ac = A'  # This is a simple way to remove the adjoint
+    Ac = transepose(A)  # This is a simple way to remove the adjoint
     num_rows=length(rows)
     columns = convert(Vector{Cint},SparseArrays.rowvals(Ac))
     columns .-= 1

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -401,9 +401,8 @@ function LQOI.get_number_variables(instance::Optimizer)
 end
 
 function LQOI.add_variables!(instance::Optimizer, number_of_variables::Int)
-    for i in 1:number_of_variables
-        add_column(instance.inner, Cint(0), Int32[], Float64[], -Inf, Inf, 0.0)
-    end
+    bounds_array=fill(Float64(Inf), number_of_variables)
+    add_columns(instance.inner, -bounds_array, bounds_array, zeros(Float64,number_of_variables), SparseArrays.spzeros(Float64, Cint, 1, number_of_variables))
 end
 
 function LQOI.delete_variables!(instance::Optimizer, start_col::Int, end_col::Int)

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -138,20 +138,16 @@ with upper bound `upper` and lower bound  `lower` to the instance `instance`.
 function append_row(instance::Optimizer, row::Int, lower::Float64,
                     upper::Float64, rows::Vector{Int}, cols::Vector{Int},
                     coefs::Vector{Float64})
-    indices = if row == length(rows)
-        rows[row]:length(cols)
-    else
-        rows[row]:(rows[row+1]-1)
-    end
+    indices = rows[row]:(rows[row+1]-1)
     add_row(instance.inner, Cint(length(indices)), Cint.(cols[indices] .- 1),
             coefs[indices], lower, upper)
 end
 
 function LQOI.add_linear_constraints!(instance::Optimizer, A::LQOI.CSRMatrix{Float64},
         senses::Vector{Cchar}, right_hand_sides::Vector{Float64})
-    rows = A.row_pointers
-    cols = A.columns
-    coefs = A.coefficients
+    rows = LQOI.row_pointers(A)
+    cols = LQOI.colvals(A)
+    coefs = LQOI.nonzeros(A)
     for (row, (rhs, sense)) in enumerate(zip(right_hand_sides, senses))
         if rhs > 1e20
             error("rhs must always be less than 1e20")

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -26,12 +26,16 @@ end
         "linear1",
         # linear10 test is tested below because it has interval sets.
         "linear10",
+        "linear10b",
         # linear11 test is excluded as it fails on Linux for some reason.
         # It passes on Mac and Windows.
         "linear11",
         # linear12 test requires the InfeasibilityCertificate for variable
         # bounds. These are available through C++, but not via the C interface.
-        "linear12"
+        "linear12",
+        # partial_start requires VariablePrimalStart to be implemented by the
+        # solver.
+        "partial_start"
     ])
 
     @testset "Interval Bridge" begin
@@ -49,7 +53,7 @@ end
     end
     @testset "emptytest" begin
         MOIT.emptytest(solver)
-    end 
+    end
     @testset "copytest" begin
         solver2 = Clp.Optimizer(LogLevel = 0)
         MOIT.copytest(solver,solver2)


### PR DESCRIPTION
This significantly improves the tine it takes to copy the model when in caching mode.   Mostly this is achieved through the use of add_rows & add_columns rather than their singular counterparts. 

This pull is dependant on the following PR:
https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/96
https://github.com/JuliaOpt/MathOptInterface.jl/pull/696

Benchmarking will follow.