### PR TITLE
Fix ccall to maximumIterations

### DIFF
--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -631,6 +631,8 @@ end
 # Get maximum number of iterations
 function maximum_iterations(model::ClpModel)
     _jl__check_model(model)
+    # The C function's name does not follow the `Clp_` convention
+    # See https://github.com/JuliaOpt/Clp.jl/issues/67
     ccall((:maximumIterations, libClp), Int32, (Ptr{Cvoid},), model.p)
 end
 

--- a/src/ClpCInterface.jl
+++ b/src/ClpCInterface.jl
@@ -631,7 +631,7 @@ end
 # Get maximum number of iterations
 function maximum_iterations(model::ClpModel)
     _jl__check_model(model)
-    @clp_ccall maximumIterations Int32 (Ptr{Cvoid},) model.p
+    ccall((:maximumIterations, libClp), Int32, (Ptr{Cvoid},), model.p)
 end
 
 # Set maximum number of iterations


### PR DESCRIPTION
See #67

> It looks like they called it `maximumIterations` instead of `Clp_maximumIterations`.

The proposed fix replaces the `@clp_ccall` with a regular `ccall` to the correct C function.

```julia
import Clp

m = Clp.ClpModel()
Clp.maximum_iterations(m)  # no error anymore, should return typemax(Int32)
```

In the long term, I guess it'd be preferable that the C function's name goes back to `Clp_maximumIterations`, but I don't know how long that would take.