### PR TITLE
Switch to loadProblem instead of incremental building and tidy MOI wrapper

### DIFF
--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -136,8 +136,8 @@ MOI.supports(::Optimizer, ::MOI.NumberOfThreads) = false
 # ========================================
 
 function MOI.supports_constraint(
-    ::Optimizer, ::Type{MOI.ScalarAffineFunction{Float64}}, ::Type{S}
-) where {S<:SCALAR_SETS}
+    ::Optimizer, ::Type{MOI.ScalarAffineFunction{Float64}}, ::Type{<:SCALAR_SETS}
+)
     return true
 end
 
@@ -336,7 +336,6 @@ function MOI.get(model::Optimizer, ::MOI.RawStatusString)
 end
 
 function MOI.get(model::Optimizer, ::MOI.ResultCount)
-    st = MOI.get(model, MOI.TerminationStatus())
     if Clp.primal_feasible(model.inner)
         return 1
     elseif Clp.dual_feasible(model.inner)
@@ -414,8 +413,8 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintPrimal,
-    c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}
-) where {S<:SCALAR_SETS}
+    c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, <:SCALAR_SETS}
+)
     MOI.check_result_index_bounds(model, attr)
     sol = Clp.get_row_activity(model.inner)
     return sol[c.value]
@@ -425,8 +424,8 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintPrimal,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}
-) where {S<:SCALAR_SETS}
+    c::MOI.ConstraintIndex{MOI.SingleVariable, <:SCALAR_SETS}
+)
     MOI.check_result_index_bounds(model, attr)
     return MOI.get(model, MOI.VariablePrimal(), MOI.VariableIndex(c.value))
 end
@@ -442,8 +441,8 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}
-) where {S<:SCALAR_SETS}
+    c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, <:SCALAR_SETS}
+)
     MOI.check_result_index_bounds(model, attr)
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
     dual_status = MOI.get(model, MOI.DualStatus())
@@ -496,8 +495,11 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}
-) where {S<:Union{MOI.Interval{Float64}, MOI.EqualTo{Float64}}}
+    c::MOI.ConstraintIndex{
+        MOI.SingleVariable,
+        <:Union{MOI.Interval{Float64}, MOI.EqualTo{Float64}}
+    }
+)
     MOI.check_result_index_bounds(model, attr)
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
     return sense * Clp.get_reduced_cost(model.inner)[c.value]

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -1,14 +1,8 @@
 import MathOptInterface
-const MOI = MathOptInterface
-const MOIU = MathOptInterface.Utilities
-
+import SparseArrays
 using .ClpCInterface
 
-# Helper functions
-_bounds(s::MOI.GreaterThan{Float64}) = (s.lower, Inf)
-_bounds(s::MOI.LessThan{Float64}) = (-Inf, s.upper)
-_bounds(s::MOI.EqualTo{Float64}) = (s.value, s.value)
-_bounds(s::MOI.Interval{Float64}) = (s.lower, s.upper)
+const MOI = MathOptInterface
 
 # Supported scalar sets
 const SCALAR_SETS = Union{
@@ -38,24 +32,17 @@ const SOLVE_OPTION_MAP = Dict(
 )
 
 mutable struct Optimizer <: MOI.AbstractOptimizer
-    # Inner Clp object
     inner::Clp.ClpModel
-
-    # Clp solve options
     solver_options::Clp.ClpSolve
     options_set::Set{Symbol}
-    # To handle MOI.OPTIMIZE_NOT_CALLED status
     optimize_called::Bool
-
     function Optimizer(;kwargs...)
         inner_model = Clp.ClpModel()
         solver_options = Clp.ClpSolve()
         model = new(inner_model, solver_options, Set{Symbol}(), false)
-
         for (key, value) in kwargs
             MOI.set(model, MOI.RawParameter(String(key)), value)
         end
-
         return model
     end
 end
@@ -63,8 +50,9 @@ end
 # ====================
 #   empty functions
 # ====================
+
 function MOI.is_empty(model::Optimizer)
-    # A problem is empty if it has no variable and no linear constraint
+    # A problem is empty if it has no variable and no linear constraints
     return (Clp.get_num_rows(model.inner) == 0) && (Clp.get_num_cols(model.inner) == 0)
 end
 
@@ -79,7 +67,6 @@ function MOI.empty!(model::Optimizer)
     model.optimize_called = false
     return
 end
-
 
 MOI.get(::Optimizer, ::MOI.SolverName) = "Clp"
 
@@ -118,7 +105,7 @@ function MOI.set(model::Optimizer, ::MOI.Silent, value::Bool)
     else
         Clp.set_log_level(model.inner, 1)
     end
-    return nothing
+    return
 end
 
 function MOI.get(model::Optimizer, ::MOI.Silent)
@@ -135,7 +122,7 @@ function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, value)
     else
         Clp.set_maximum_seconds(model.inner, value)
     end
-    return nothing
+    return
 end
 
 # Clp behaves weird here
@@ -147,174 +134,146 @@ MOI.supports(::Optimizer, ::MOI.NumberOfThreads) = false
 # ========================================
 #   Supported constraints and objectives
 # ========================================
-MOI.supports_constraint(::Optimizer,
-    ::Type{MOI.ScalarAffineFunction{Float64}}, ::Type{<:SCALAR_SETS}
-) = true
 
-MOI.supports_constraint(::Optimizer,
-    ::Type{MOI.SingleVariable}, ::Type{<:SCALAR_SETS}
-) = true
+function MOI.supports_constraint(
+    ::Optimizer, ::Type{MOI.ScalarAffineFunction{Float64}}, ::Type{S}
+) where {S<:SCALAR_SETS}
+    return true
+end
+
+function MOI.supports_constraint(
+    ::Optimizer, ::Type{MOI.SingleVariable}, ::Type{<:SCALAR_SETS}
+)
+    return true
+end
 
 MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true
 
-MOI.supports(::Optimizer,
-    ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}
-) = true
+function MOI.supports(
+    ::Optimizer, ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}
+)
+    return true
+end
 
 # =======================
 #   `copy_to` function
 # =======================
 
+_add_bounds(::Vector{Float64}, ub, i, s::MOI.LessThan{Float64}) = ub[i] = s.upper
+_add_bounds(lb, ::Vector{Float64}, i, s::MOI.GreaterThan{Float64}) = lb[i] = s.lower
+_add_bounds(lb, ub, i, s::MOI.EqualTo{Float64}) = lb[i], ub[i] = s.value, s.value
+_add_bounds(lb, ub, i, s::MOI.Interval{Float64}) = lb[i], ub[i] = s.lower, s.upper
+
+function _extract_bound_data(src, mapping, lb, ub, S)
+    for con_index in MOI.get(
+        src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
+    )
+        f = MOI.get(src, MOI.ConstraintFunction(), con_index)
+        s = MOI.get(src, MOI.ConstraintSet(), con_index)
+        column = mapping.varmap[f.variable].value
+        _add_bounds(lb, ub, column, s)
+        mapping.conmap[con_index] = MOI.ConstraintIndex{MOI.SingleVariable, S}(column)
+    end
+end
+
+function _copy_to_columns(dest, src, mapping)
+    x_src = MOI.get(src, MOI.ListOfVariableIndices())
+    N = Cint(length(x_src))
+    for i = 1:N
+        mapping.varmap[x_src[i]] = MOI.VariableIndex(i)
+    end
+
+    fobj = MOI.get(src, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    c = fill(0.0, N)
+    for term in fobj.terms
+        i = mapping.varmap[term.variable_index].value
+        c[i] += term.coefficient
+    end
+    # Clp seems to negates the objective offset
+    Clp.set_objective_offset(dest.inner, -fobj.constant)
+    return N, c
+end
+
+_bounds(s::MOI.GreaterThan{Float64}) = (s.lower, Inf)
+_bounds(s::MOI.LessThan{Float64}) = (-Inf, s.upper)
+_bounds(s::MOI.EqualTo{Float64}) = (s.value, s.value)
+_bounds(s::MOI.Interval{Float64}) = (s.lower, s.upper)
+
+function _extract_row_data(src, mapping, lb, ub, I, J, V, S)
+    row = length(I) == 0 ? 1 : I[end] + 1
+    for c_index in MOI.get(
+        src, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}()
+    )
+        f = MOI.get(src, MOI.ConstraintFunction(), c_index)
+        l, u = _bounds(MOI.get(src, MOI.ConstraintSet(), c_index))
+        push!(lb, l - f.constant)
+        push!(ub, u - f.constant)
+        for term in f.terms
+            push!(I, row)
+            push!(J, Cint(mapping.varmap[term.variable_index].value))
+            push!(V, term.coefficient)
+        end
+        mapping.conmap[c_index] = MOI.ConstraintIndex{
+            MOI.ScalarAffineFunction{Float64}, S
+        }(length(ub))
+        row += 1
+    end
+    return
+end
+
 function MOI.copy_to(
     dest::Optimizer,
     src::MOI.ModelLike;
-    copy_names=false
+    copy_names::Bool = false
 )
-    # Check that all constraints and objectives
+    @assert MOI.is_empty(dest)
     for (F, S) in MOI.get(src, MOI.ListOfConstraints())
-        MOI.supports_constraint(dest, F, S) || throw(MOI.UnsupportedConstraint{F, S}(
-            "Clp.Optimizer does not support constraints of type $F-in-$S."
-        ))
+        if !MOI.supports_constraint(dest, F, S)
+            throw(MOI.UnsupportedConstraint{F, S}("Clp.Optimizer does not support constraints of type $F-in-$S."))
+        end
     end
     fobj_type = MOI.get(src, MOI.ObjectiveFunctionType())
-    MOI.supports(dest, MOI.ObjectiveFunction{fobj_type}()) || throw(
-        MOI.UnsupportedAttribute(MOI.ObjectiveFunction(fobj))
+    if !MOI.supports(dest, MOI.ObjectiveFunction{fobj_type}())
+        throw(MOI.UnsupportedAttribute(MOI.ObjectiveFunction(fobj_type)))
+    end
+    mapping = MOI.Utilities.IndexMap()
+    N, c = _copy_to_columns(dest, src, mapping)
+    cl, cu = fill(-Inf, N), fill(Inf, N)
+    rl, ru, I, J, V = Float64[], Float64[], Cint[], Cint[], Float64[]
+    for S in (
+        MOI.GreaterThan{Float64},
+        MOI.LessThan{Float64},
+        MOI.EqualTo{Float64},
+        MOI.Interval{Float64},
+    )
+        _extract_bound_data(src, mapping, cl, cu, S)
+        _extract_row_data(src, mapping, rl, ru, I, J, V, S)
+    end
+    M = Cint(length(rl))
+    A = SparseArrays.sparse(I, J, V, M, N)
+    Clp.load_problem(
+        dest.inner,
+        A.n,
+        A.m,
+        A.colptr .- Cint(1),
+        A.rowval .- Cint(1),
+        A.nzval,
+        cl,
+        cu,
+        c,
+        rl,
+        ru
     )
 
-    # Empty dest
-    MOI.empty!(dest)
-
-    mapping = MOIU.IndexMap()
-
-    # First create variables (including bounds)
-
-    # Create variables
-    # TODO: it may be more efficient to create the problem all at once
-    x_src = MOI.get(src, MOI.ListOfVariableIndices())
-    for (j, x) in enumerate(x_src)
-        # Variable j corresponds to j-th variable of x_src
-        mapping.varmap[x] = MOI.VariableIndex(j)
-
-        # Possible bound combinations:
-        #=
-            * No bound (default case)
-            * Interval
-            * EqualTo
-            * LessThan
-            * GreaterThan
-            * LessThan && GreaterThan
-        =#
-        lb, ub = -Inf, Inf  # Default case: free variable
-
-        idx_RG = MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}(x.value)
-        idx_ET = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(x.value)
-        idx_LT = MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}(x.value)
-        idx_GT = MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}(x.value)
-        if MOI.is_valid(src, idx_LT)
-            # Get the (upper) bound
-            s = MOI.get(src, MOI.ConstraintSet(), idx_LT)
-            ub = s.upper
-
-            # Track index of upper-bound constraint
-            mapping.conmap[idx_LT] = MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}(j)
-        end
-        if MOI.is_valid(src, idx_GT)
-            # Get the (lower) bound
-            s = MOI.get(src, MOI.ConstraintSet(), idx_GT)
-            lb = s.lower
-
-            # Track index of upper-bound constraint
-            mapping.conmap[idx_GT] = MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}(j)
-        end
-        if MOI.is_valid(src, idx_RG)
-            # Get upper and lower bound
-            s = MOI.get(src, MOI.ConstraintSet(), idx_RG)
-            lb, ub = s.lower, s.upper
-
-            # Track index of upper-bound constraint
-            mapping.conmap[idx_RG] = MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}(j)
-        end
-        if MOI.is_valid(src, idx_ET)
-            # Get the bounds
-            s = MOI.get(src, MOI.ConstraintSet(), idx_ET)
-            lb, ub = s.value, s.value
-
-            # Track index of upper-bound constraint
-            mapping.conmap[idx_ET] = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(j)
-        end
-
-        Clp.add_column(dest.inner, Cint(0), Int32[], Float64[], lb, ub, 0.0)
-    end
-
-    # Create linear constraints
-    nrows = 0  # number of rows in the problem
-    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
-        # Check if constraint is a linear constraint
-        (F == MOI.ScalarAffineFunction{Float64}) || continue
-
-        for index in MOI.get(src, MOI.ListOfConstraintIndices{F, S}())
-            # Retrieve problem data
-            # TODO: ensure that `(f, s)` are in canonical form
-            f = MOIU.canonical(MOI.get(src, MOI.ConstraintFunction(), index))
-            s = MOI.get(src, MOI.ConstraintSet(), index)
-
-            # Extract bounds
-            # Constraint writes a'x + a0 - in - set
-            # So we offset the bounds by -a0
-            lb, ub = _bounds(s) .- f.constant
-
-            # Identify constraint terms
-            coeffs = [t.coefficient for t in f.terms]
-            cols::Vector{Int} = [
-                mapping.varmap[t.variable_index].value
-                for t in f.terms
-            ]
-
-            # Add constraint
-            Clp.add_row(dest.inner, Cint(length(f.terms)), Cint.(cols .- 1), coeffs, lb, ub)
-
-            # Track index
-            mapping.conmap[index] = MOI.ConstraintIndex{F, S}(nrows + 1)
-            nrows += 1
-        end
-    end
-
-    # Objective function
     sense = MOI.get(src, MOI.ObjectiveSense())
     if sense == MOI.MIN_SENSE
-        Clp.set_obj_sense(dest.inner, 1)   # minimize
+        Clp.set_obj_sense(dest.inner, 1)
     elseif sense == MOI.MAX_SENSE
-        Clp.set_obj_sense(dest.inner, -1)  # maximize
-    elseif sense == MOI.FEASIBILITY_SENSE
-        Clp.set_obj_sense(dest.inner, 0)   # feasibility
+        Clp.set_obj_sense(dest.inner, -1)
     else
-        # Should not be reached, but just in case
-        error("Unexpected optimization sense $sense")
+        @assert sense == MOI.FEASIBILITY_SENSE
+        Clp.set_obj_sense(dest.inner, 0)
     end
-
-    fobj = MOI.get(src, MOI.ObjectiveFunction{fobj_type}())
-    obj_coeffs = zeros(length(x_src))
-    obj_offset = 0.0
-
-    if fobj_type == MOI.ScalarAffineFunction{Float64}
-        # Record objective coeffs
-        for term in fobj.terms
-            x = mapping.varmap[term.variable_index]
-            # Here we do += instead of = to accumulate dupplicates
-            obj_coeffs[x.value] += term.coefficient
-        end
-        obj_offset = fobj.constant
-    else
-        # Should not be reached here, but just in case
-        error("Unexpected objective $fobj")
-    end
-
-    # Set objective coefficients
-    Clp.chg_obj_coefficients(dest.inner, obj_coeffs)
-    # Set objective offset
-    # Clp seems to negates the objective offset
-    Clp.set_objective_offset(dest.inner, -obj_offset)
-
     return mapping
 end
 
@@ -325,24 +284,23 @@ end
 function MOI.optimize!(model::Optimizer)
     Clp.initial_solve_with_options(model.inner, model.solver_options)
     model.optimize_called = true
-    return nothing
+    return
 end
 
-MOI.get(model::Optimizer, ::MOI.NumberOfVariables) = Clp.get_num_cols(model.inner)
+function MOI.get(model::Optimizer, ::MOI.NumberOfVariables)
+    return Clp.get_num_cols(model.inner)
+end
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
-    # Check result index
     MOI.check_result_index_bounds(model, attr)
-
     return Clp.get_obj_value(model.inner)
 end
 
 function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
-
-    model.optimize_called || return MOI.OPTIMIZE_NOT_CALLED
-
+    if !model.optimize_called
+        return MOI.OPTIMIZE_NOT_CALLED
+    end
     st = Clp.status(model.inner)
-
     if st == 0
         return MOI.OPTIMAL
     elseif st == 1
@@ -358,8 +316,9 @@ function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
 end
 
 function MOI.get(model::Optimizer, ::MOI.RawStatusString)
-    model.optimize_called || return "MOI.OPTIMIZE_NOT_CALLED"
-
+    if !model.optimize_called
+        return "MOI.OPTIMIZE_NOT_CALLED"
+    end
     st = Clp.status(model.inner)
     if st == 0
         return "0 - optimal"
@@ -378,20 +337,22 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.ResultCount)
     st = MOI.get(model, MOI.TerminationStatus())
-
-    # TODO: check that this is correct
-    if st == MOI.OPTIMIZE_NOT_CALLED || st == MOI.OTHER_ERROR
-        return 0
+    if Clp.primal_feasible(model.inner)
+        return 1
+    elseif Clp.dual_feasible(model.inner)
+        return 1
+    elseif Clp.is_proven_primal_infeasible(model.inner)
+        return 1
+    elseif Clp.is_proven_dual_infeasible(model.inner)
+        return 1
     end
-    return 1
+    return 0
 end
 
-# Solution status
 function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
-    # Check result index
-    attr.N == 1 || return MOI.NO_SOLUTION
-
-    if Clp.is_proven_dual_infeasible(model.inner)
+    if attr.N != 1
+        return MOI.NO_SOLUTION
+    elseif Clp.is_proven_dual_infeasible(model.inner)
         return MOI.INFEASIBILITY_CERTIFICATE
     elseif Clp.primal_feasible(model.inner)
         return MOI.FEASIBLE_POINT
@@ -401,10 +362,9 @@ function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
 end
 
 function MOI.get(model::Optimizer, attr::MOI.DualStatus)
-    # Check result index
-    attr.N == 1 || return MOI.NO_SOLUTION
-
-    if Clp.is_proven_primal_infeasible(model.inner)
+    if attr.N != 1
+        return MOI.NO_SOLUTION
+    elseif Clp.is_proven_primal_infeasible(model.inner)
         return MOI.INFEASIBILITY_CERTIFICATE
     elseif Clp.dual_feasible(model.inner)
         return MOI.FEASIBLE_POINT
@@ -416,12 +376,11 @@ end
 # ===================
 #   Primal solution
 # ===================
-function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, x::MOI.VariableIndex)
-    # Check result index
-    MOI.check_result_index_bounds(model, attr)
 
-    # We assume the variable index is valid,
-    # since Clp should be accessed via a CachingOptimizer
+function MOI.get(
+    model::Optimizer, attr::MOI.VariablePrimal, x::MOI.VariableIndex
+)
+    MOI.check_result_index_bounds(model, attr)
     primal_status = MOI.get(model, MOI.PrimalStatus())
     if primal_status == MOI.INFEASIBILITY_CERTIFICATE
         sol = Clp.unbounded_ray(model.inner)
@@ -434,14 +393,11 @@ function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, x::MOI.VariableInde
     end
 end
 
-function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, xs::Vector{MOI.VariableIndex})
-    # Check result index
+function MOI.get(
+    model::Optimizer, attr::MOI.VariablePrimal, xs::Vector{MOI.VariableIndex}
+)
     MOI.check_result_index_bounds(model, attr)
-
     col_indices = [idx.value for idx in xs]
-
-    # We assume all variable indices is valid,
-    # since Clp should be accessed via a CachingOptimizer
     primal_status = MOI.get(model, MOI.PrimalStatus())
     if primal_status == MOI.INFEASIBILITY_CERTIFICATE
         sol = Clp.unbounded_ray(model.inner)
@@ -454,28 +410,24 @@ function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, xs::Vector{MOI.Vari
     end
 end
 
-function MOI.get(model::Optimizer, attr::MOI.ConstraintPrimal,
+# TODO: What happens if model is unbounded / infeasible?
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintPrimal,
     c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}
-) where{S <:SCALAR_SETS}
-    # Check result index
+) where {S<:SCALAR_SETS}
     MOI.check_result_index_bounds(model, attr)
-
-    # We assume that the constraint index is valid,
-    # since Clp should be accessed via a CachingOptimizer
-    # TODO: What happens if model is unbounded / infeasible?
-
-    # Get primal row solution
     sol = Clp.get_row_activity(model.inner)
     return sol[c.value]
 end
 
-function MOI.get(model::Optimizer, attr::MOI.ConstraintPrimal,
+# TODO: What happens if model is unbounded / infeasible?
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintPrimal,
     c::MOI.ConstraintIndex{MOI.SingleVariable, S}
-) where{S <: SCALAR_SETS}
-    # Check result index
+) where {S<:SCALAR_SETS}
     MOI.check_result_index_bounds(model, attr)
-
-    # TODO: What happens if model is unbounded / infeasible?
     return MOI.get(model, MOI.VariablePrimal(), MOI.VariableIndex(c.value))
 end
 
@@ -483,43 +435,38 @@ end
 # =================
 #   Dual solution
 # =================
+
 # If sense is maximize, we negate all the duals to follow MOI conventions
 # Feasibility problems are treated as a minimization
-function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
+
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
     c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}
-) where{S <: SCALAR_SETS}
-    # Check result index
+) where {S<:SCALAR_SETS}
     MOI.check_result_index_bounds(model, attr)
-
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
-
     dual_status = MOI.get(model, MOI.DualStatus())
     if dual_status == MOI.FEASIBLE_POINT
-        # Return dual solution
         dsol = Clp.get_row_price(model.inner)
         return sense * dsol[c.value]
     elseif dual_status == MOI.INFEASIBILITY_CERTIFICATE
-        # Return infeasibility ray
         dsol = Clp.infeasibility_ray(model.inner)
         return sense * dsol[c.value]
     else
-        # Throw error if dual solution is not available
         error("Dual solution not available")
     end
 end
 
-# Reduced costs
 # TODO: what happens if problem is unbounded / infeasible?
-function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
     c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}
 )
-    # Check result index
     MOI.check_result_index_bounds(model, attr)
-
     rc = Clp.get_reduced_cost(model.inner)[c.value]
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
-
-    # Dual should be non-positive
     if sense == 1 && rc <= 0.0
         return rc
     elseif sense == -1 && rc >= 0.0
@@ -529,16 +476,14 @@ function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
     end
 end
 
-function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
     c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}
 )
-    # Check result index
     MOI.check_result_index_bounds(model, attr)
-
     rc = Clp.get_reduced_cost(model.inner)[c.value]
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
-
-    # Dual should be non-negative
     if sense == 1 && rc >= 0.0
         return rc
     elseif sense == -1 && rc <= 0.0
@@ -548,12 +493,12 @@ function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
     end
 end
 
-function MOI.get(model::Optimizer, attr::MOI.ConstraintDual,
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
     c::MOI.ConstraintIndex{MOI.SingleVariable, S}
-) where{S <: Union{MOI.Interval{Float64}, MOI.EqualTo{Float64}}}
-    # Check result index
+) where {S<:Union{MOI.Interval{Float64}, MOI.EqualTo{Float64}}}
     MOI.check_result_index_bounds(model, attr)
-
     sense = (Clp.get_obj_sense(model.inner) == -1) ? -1 : 1
     return sense * Clp.get_reduced_cost(model.inner)[c.value]
 end

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -1,11 +1,9 @@
-using Test, MathOptInterface
+using Test
+using MathOptInterface
+import Clp
 
 const MOI  = MathOptInterface
-const MOIB = MathOptInterface.Bridges
-const MOIT = MathOptInterface.Test
-const MOIU = MOI.Utilities
 
-import Clp
 const OPTIMIZER = Clp.Optimizer()
 MOI.set(OPTIMIZER, MOI.Silent(), true)
 
@@ -14,88 +12,87 @@ MOI.set(OPTIMIZER, MOI.Silent(), true)
 end
 
 @testset "supports_default_copy_to" begin
-    @test !MOIU.supports_allocate_load(OPTIMIZER, false)
-    @test !MOIU.supports_allocate_load(OPTIMIZER, true)
-    @test !MOIU.supports_default_copy_to(OPTIMIZER, false)
-    @test !MOIU.supports_default_copy_to(OPTIMIZER, true)
+    @test !MOI.Utilities.supports_allocate_load(OPTIMIZER, false)
+    @test !MOI.Utilities.supports_allocate_load(OPTIMIZER, true)
+    @test !MOI.Utilities.supports_default_copy_to(OPTIMIZER, false)
+    @test !MOI.Utilities.supports_default_copy_to(OPTIMIZER, true)
 end
 
-const CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
-const CACHED = MOIU.CachingOptimizer(CACHE, OPTIMIZER)
-MOI.set(CACHED, MOI.Silent(), true)
+const CACHED = MOI.Utilities.CachingOptimizer(
+    MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    OPTIMIZER
+)
 
 const BRIDGED = MOI.Bridges.full_bridge_optimizer(CACHED, Float64)
-MOI.set(BRIDGED, MOI.Silent(), true)
 
-const CONFIG = MOIT.TestConfig(
-    dual_objective_value=false
+const CONFIG = MOI.Test.TestConfig(
+    dual_objective_value = false,
 )
 
 @testset "basic_constraint_tests" begin
-    MOIT.basic_constraint_tests(CACHED, CONFIG)
+    MOI.Test.basic_constraint_tests(CACHED, CONFIG)
 end
 
 @testset "Unit Tests" begin
-    MOIT.unittest(BRIDGED, CONFIG, [
-        # Unsupported attributes
-        "number_threads",  # not supported by Clp
-        "time_limit_sec",  # Weird behaviour of Clp
-        "solve_time",  # not supported by Clp
+    MOI.Test.unittest(BRIDGED, CONFIG, [
+        # Attributes not yet implemented.
+        # TODO(odow): implement these attributes.
+        "number_threads",
+        "time_limit_sec",
+        "solve_time",
+
         # Tests that require integer variables
         "solve_integer_edge_cases",
         "solve_zero_one_with_bounds_1",
         "solve_zero_one_with_bounds_2",
         "solve_zero_one_with_bounds_3",
         "solve_objbound_edge_cases",
+
         # Tests that require quadratic objective / constraints
         "solve_qcp_edge_cases",
         "solve_qp_edge_cases",
-        # Tests that require SOC
         "delete_soc_variables",
     ])
 end
 
 @testset "Linear tests" begin
-    MOIT.contlineartest(BRIDGED, CONFIG, [
-        # Queries an infeasibility certificate
+    MOI.Test.contlineartest(BRIDGED, CONFIG, [
+        # TODO(odow): investigate error.
         "linear8a",
-        # linear12 test requires the InfeasibilityCertificate for variable
+
+        # The linear12 test requires the InfeasibilityCertificate for variable
         # bounds. These are available through C++, but not via the C interface.
         "linear12",
-        # partial_start requires VariablePrimalStart to be implemented by the
-        # solver.
+
+        # MOI.VariablePrimalStart not implemented.
         "partial_start"
     ])
 end
 
 @testset "ModelLike" begin
-    # solver = Clp.Optimizer(LogLevel = 0)
     @testset "nametest" begin
-        MOIT.nametest(BRIDGED)
+        MOI.Test.nametest(BRIDGED)
     end
     @testset "validtest" begin
-        MOIT.validtest(BRIDGED)
+        MOI.Test.validtest(BRIDGED)
     end
     @testset "emptytest" begin
-        MOIT.emptytest(BRIDGED)
+        MOI.Test.emptytest(BRIDGED)
     end
-    # @testset "copytest" begin
-    #     solver2 = Clp.Optimizer(LogLevel = 0)
-    #     MOIT.copytest(solver,solver2)
-    # end
-    # Clp returns C_NULL when queried for the infeasibility ray in this case.
-    @testset "Inexistant unbounded ray" begin
-        # o = Clp.Optimizer(LogLevel = 0)
-        MOI.empty!(BRIDGED)
+end
 
-        x = MOI.add_variables(BRIDGED, 5)
-        MOI.set(BRIDGED, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-                   MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0))
-        MOI.set(BRIDGED, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-        MOI.optimize!(BRIDGED)
-        status = MOI.get(BRIDGED, MOI.TerminationStatus())
-        @test status == MOI.DUAL_INFEASIBLE
-    end
+@testset "Nonexistant unbounded ray" begin
+    MOI.empty!(BRIDGED)
+    x = MOI.add_variables(BRIDGED, 5)
+    MOI.set(
+        BRIDGED,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0)
+    )
+    MOI.set(BRIDGED, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.optimize!(BRIDGED)
+    status = MOI.get(BRIDGED, MOI.TerminationStatus())
+    @test status == MOI.DUAL_INFEASIBLE
 end
 
 @testset "RawParameter" begin


### PR DESCRIPTION
Notably, on the `test_1.mps` problem from this post, https://discourse.julialang.org/t/cbc-and-clp-performance/38505/6, we go from not even finishing the load in 10 minutes, to 40 seconds.

```Julia
julia> model
A JuMP Model
Minimization problem with:
Variables: 574369
Objective function type: VariableRef
`GenericAffExpr{Float64,VariableRef}`-in-`MathOptInterface.EqualTo{Float64}`: 156985 constraints
`GenericAffExpr{Float64,VariableRef}`-in-`MathOptInterface.GreaterThan{Float64}`: 401756 constraints
`GenericAffExpr{Float64,VariableRef}`-in-`MathOptInterface.LessThan{Float64}`: 319172 constraints
`VariableRef`-in-`MathOptInterface.GreaterThan{Float64}`: 566929 constraints
Model mode: AUTOMATIC
CachingOptimizer state: ATTACHED_OPTIMIZER
Solver name: Clp
```

Here's the last bit of the `optimize!` log:
```
Clp0000I Optimal - objective value 1.8732729e+09
Coin0511I After Postsolve, objective 1.8732729e+09, infeasibilities - dual 28018158 (5423), primal 0.00073130792 (15)
Coin0512I Presolved model was optimal, full model needs cleaning up
Clp0006I 0  Obj 1.8732729e+09 Primal inf 8.9651245e-06 (14) Dual inf 1.3999997e+09 (14)
Clp0006I 211  Obj 1.8732729e+09 Primal inf 2.4652618e-06 (3) Dual inf 2.9999989e+08 (3)
Clp0029I End of values pass after 331 iterations
Clp0006I 331  Obj 1.8732729e+09
Clp0000I Optimal - objective value 1.8732729e+09
Clp0032I Optimal objective 1873272903 - 461755 iterations time 841.682, Presolve 25.13
882.713930 seconds (115.69 M allocations: 4.828 GiB, 0.49% gc time)
```